### PR TITLE
Issue with the npm run codegen:gen not working

### DIFF
--- a/Code/frontend/package.json
+++ b/Code/frontend/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "codegen:schema": "npx apollo client:download-schema --endpoint=http://localhost:2022/api --key=service:grad-project-edtunn:kJYu15IU1j-EJcf8PoadHA",
-    "codegen:generate": "npx apollo client:codegen --localSchemaFile=schema.json --includes=src/**/*.tsx  --target=typescript",
+    "codegen:gen": "npx apollo client:codegen --localSchemaFile=schema.json --includes=src/**/*.tsx  --target=typescript",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
  While there are two steps that needs to be followed:

-The codegen:schema scripts works fine. Afterwards I'll have to run the codegen:gen script which ends up with an error.It should create __generated__ folder.

![image](https://user-images.githubusercontent.com/48670775/172745726-30c124a7-92e7-4e13-b46b-a8caead8d778.png)

√ Loading Apollo Project
  × Generating query files with 'typescript' target
    → Cannot query field "deleteListing" on type "Mutatio
n"
    GraphQLError: Cannot query field "deleteListing" on
    type "Mutation"